### PR TITLE
Fixed incorrect prop name for SideMenu toggle

### DIFF
--- a/src/AppRootContainer.js
+++ b/src/AppRootContainer.js
@@ -69,7 +69,7 @@ class AppRootContainer extends Component {
     return (
       <SideMenu
         toggledContainerStyle={{borderLeftWidth: 1, borderLeftColor: '#ededed'}}
-        toggled={this.state.toggled}
+        isOpen={this.state.toggled}
         MenuComponent={MenuComponent}>
         <App toggleSideMenu={this.toggleSideMenu} />
       </SideMenu>


### PR DESCRIPTION
Renamed SideMenu toggled prop to isOpen per the spec for React Native Elements. The SideMenu toggle was broken, now works after prop toggled was renamed isOpen.