### PR TITLE
Add missing refs on More tab

### DIFF
--- a/src/more/More.js
+++ b/src/more/More.js
@@ -97,6 +97,7 @@ class More extends Component {
           <SearchBar
             noIcon
             clearIcon
+            textInputRef="searchBar1"
             placeholder='Type Here...' />
         </View>
         <View style={{marginTop: 10, marginBottom: 0}}>
@@ -108,6 +109,7 @@ class More extends Component {
           <SearchBar
             lightTheme
             clearIcon
+            textInputRef="searchBar2"
             placeholder='Type Here...' />
         </View>
         <View style={{marginTop: 10, marginBottom: 0}}>


### PR DESCRIPTION
The first two `SearchBar` components that have the `clearIcon` are missing the needed refs. Without them, the following error screen is presented.

<img width="487" alt="screen shot 2017-07-10 at 2 02 15 pm" src="https://user-images.githubusercontent.com/3525886/28039858-90bedb36-6578-11e7-82ae-ab541e3772a7.png">
