### PR TITLE
Display various avatars in list screen

### DIFF
--- a/src/views/lists_home.js
+++ b/src/views/lists_home.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import Expo from 'expo';
 import React, { Component } from 'react';
 import {
@@ -103,6 +105,39 @@ const list2 = [
     subtitle: 'CTO',
   },
 ];
+
+const list3 = [
+  {
+    image_url: 'https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg',
+    icon: null,
+    title: null,
+  },
+  {
+    image_url: 'https://s3.amazonaws.com/uifaces/faces/twitter/adhamdannaway/128.jpg',
+    icon: null,
+    title: null,
+  },
+  {
+    image_url: null,
+    icon: null,
+    title: 'LR',
+  },
+  {
+    image_url: null,
+    icon: {name: 'user', type: 'font-awesome'},
+    title: null,
+  },
+  {
+    image_url: null,
+    icon: {name: 'user-female', type: 'simple-line-icon'},
+    title: null,
+  },
+  {
+    image_url: null,
+    icon: {name: 'baidu', type: 'entypo'},
+    title: null,
+  },
+]
 
 class Icons extends Component {
   constructor() {
@@ -286,11 +321,23 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
-              height: 230,
-              paddingLeft: 10,
             }}
             title="AVATARS"
           >
+            {_.chunk(list3, 3).map((chunk, chunkIndex) => (
+              <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginBottom: 10 }} key={chunkIndex}>
+                {chunk.map((l, i) => (
+                  <Avatar
+                    large
+                    rounded
+                    source={l.image_url ? { uri: l.image_url } : null}
+                    icon={l.icon}
+                    title={l.title}
+                    key={`${chunkIndex}-${i}`}
+                  />
+                ))}
+              </View>
+            ))}
           </Card>
         </View>
       </ScrollView>


### PR DESCRIPTION
Fixes in Avatar component: https://github.com/react-native-training/react-native-elements/pull/980

The PR comes from extending the `Avatar` component to support various icon type - https://github.com/react-native-training/react-native-elements/issues/942

<img width="358" alt="iphone_x_-_11_2" src="https://user-images.githubusercontent.com/729785/37245208-1745d160-2495-11e8-97e0-a16b493fb78d.png">
