### PR TITLE
Change submodule react-native-elements to HTTP URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "node_modules/react-native-elements"]
 	path = node_modules/react-native-elements
-	url = git@github.com:react-native-training/react-native-elements.git
+	url = https://github.com/react-native-training/react-native-elements.git


### PR DESCRIPTION
The README suggest cloning this project using the HTTP URL (not SSH).

But the submodules have an SSH reference to `react-native-elements`.

This only works when the user has a Github account, an SSH keypair and have added the public key to his GH account. This is very invonvenient, especially for unexperienced users (which are more likely to not use SSH) since they can't clone the project and get started.

This PR changes the submodule to use HTTP(S).