### PR TITLE
fix: Default title on button and icon paddings

### DIFF
--- a/src/views/buttons_home.js
+++ b/src/views/buttons_home.js
@@ -22,7 +22,10 @@ class Buttons extends Component {
             <Text style={styles.heading}>Buttons</Text>
           </View>
           <View style={{ alignItems: 'center' }}>
-            <Button containerStyle={{ marginVertical: 10 }} />
+            <Button
+              title={`Welcome to\nReact Native Elements`}
+              containerStyle={{ marginVertical: 10 }}
+            />
             <Button
               title="LOG IN"
               buttonStyle={{
@@ -61,7 +64,12 @@ class Buttons extends Component {
                 borderRadius: 20,
               }}
               containerStyle={{ marginVertical: 10, height: 40, width: 200 }}
-              icon={<Icon name="arrow-right" size={15} color="white" />}
+              icon={{
+                name: 'arrow-right',
+                type: 'font-awesome',
+                size: 15,
+                color: 'white',
+              }}
               iconRight
               iconContainerStyle={{ marginLeft: 5 }}
             />
@@ -104,7 +112,12 @@ class Buttons extends Component {
             <View style={styles.buttonsContainer}>
               <Button
                 title="HOME"
-                icon={<Icon name="home" size={15} color="white" />}
+                icon={{
+                  name: 'home',
+                  type: 'font-awesome',
+                  size: 15,
+                  color: 'white',
+                }}
                 iconContainerStyle={{ marginRight: 10 }}
                 titleStyle={{ fontWeight: '700' }}
                 buttonStyle={{
@@ -117,7 +130,12 @@ class Buttons extends Component {
               />
               <Button
                 title="PROFILE"
-                icon={<Icon name="user" size={15} color="white" />}
+                icon={{
+                  name: 'user',
+                  type: 'font-awesome',
+                  size: 15,
+                  color: 'white',
+                }}
                 iconRight
                 iconContainerStyle={{ marginLeft: 10 }}
                 titleStyle={{ fontWeight: '700' }}


### PR DESCRIPTION
First button was depending on the old default title of the button.
Since we removed the default "welcome to react native elements",
this button was broken and displayed nothing.

Also changed icon props on buttons to use the object so that the
correct padding is added.

| Before | After |
| -- | -- |
| ![simulator screen shot - iphone 6 - 2019-02-02 at 23 41 27](https://user-images.githubusercontent.com/5962998/52172363-20057a00-2744-11e9-880a-6cfd3865c24a.png) | ![simulator screen shot - iphone 6 - 2019-02-02 at 23 42 02](https://user-images.githubusercontent.com/5962998/52172370-357aa400-2744-11e9-8a60-1a91b2daf66e.png) |
|  ![simulator screen shot - iphone 6 - 2019-02-02 at 23 41 33](https://user-images.githubusercontent.com/5962998/52172362-20057a00-2744-11e9-9c44-2cfec8af32df.png) | ![simulator screen shot - iphone 6 - 2019-02-02 at 23 42 09](https://user-images.githubusercontent.com/5962998/52172369-357aa400-2744-11e9-92b3-f67ad085f315.png) |
