### PR TITLE
#31 Fixed Input field hiding behind keypad using KeyboardAvoidingView

### DIFF
--- a/src/views/input_home.js
+++ b/src/views/input_home.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, ScrollView, StyleSheet, Text, Dimensions } from 'react-native';
+import { View, ScrollView, StyleSheet, Text, Dimensions, KeyboardAvoidingView, Platform } from 'react-native';
 import {
   Input,
   SearchBar,
@@ -22,6 +22,7 @@ const dummySearchBarProps = {
 class InputHome extends Component {
   render() {
     return (
+      <KeyboardAvoidingView style={styles.keyboardAvoidingView} behavior={"padding"} enabled keyboardVerticalOffset={Platform.OS === "ios" ? 64 : 84}>
       <ScrollView style={styles.container} keyboardShouldPersistTaps="handled">
         <View style={styles.headerContainer}>
           <Icon color="white" name="search" size={62} />
@@ -306,6 +307,7 @@ class InputHome extends Component {
           </ThemeProvider>
         </View>
       </ScrollView>
+      </KeyboardAvoidingView>
     );
   }
 }
@@ -360,6 +362,11 @@ const styles = StyleSheet.create({
   inputContainerStyle: {
     marginTop: 16,
     width: '90%',
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
   },
 });
 


### PR DESCRIPTION
Closes #31 . 
Here I've used `KeyboardAvoidingView` with props values most suitable for inputs tab components view (and approx for both OS platforms). As for other solutions e.g. signup or login page there're less number of inputs on screen so behavior="position" better serves the purpose. But here it kind of creates issues like 1st field going out of the view (going up).
And platform specific best solutions are different. e.g. for android best solution can be no behavior at all & updating AndroidManifest.xml file android:windowSoftInputMode="adjustResize" .

@Monte9 Please review it & let me know suggestions.
