### PR TITLE
Fixed ineligible logo when in Light Mode

### DIFF
--- a/src/navigation/DrawerNavigator.js
+++ b/src/navigation/DrawerNavigator.js
@@ -1,7 +1,5 @@
 import React, { useContext } from 'react';
 import { View, Image, SafeAreaView, Switch } from 'react-native';
-import { StyleSheet } from 'react-native';
-
 import {
   DrawerContentScrollView,
   DrawerItemList,
@@ -12,7 +10,6 @@ import { ThemeReducerContext } from '../helpers/ThemeReducer';
 function CustomContentComponent(props) {
   const { ThemeState, dispatch } = useContext(ThemeReducerContext);
   const { theme } = useContext(ThemeContext);
-  let value = true;
   return (
     <SafeAreaView
       style={{ flex: 1, height: '100%', backgroundColor: theme.colors.grey5 }}

--- a/src/navigation/DrawerNavigator.js
+++ b/src/navigation/DrawerNavigator.js
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
 import { View, Image, SafeAreaView, Switch } from 'react-native';
+import { StyleSheet } from 'react-native';
+
 import {
   DrawerContentScrollView,
   DrawerItemList,
@@ -10,6 +12,7 @@ import { ThemeReducerContext } from '../helpers/ThemeReducer';
 function CustomContentComponent(props) {
   const { ThemeState, dispatch } = useContext(ThemeReducerContext);
   const { theme } = useContext(ThemeContext);
+  let value = true;
   return (
     <SafeAreaView
       style={{ flex: 1, height: '100%', backgroundColor: theme.colors.grey5 }}
@@ -23,8 +26,8 @@ function CustomContentComponent(props) {
         }}
       >
         <Image
-          source={require('../images/logo.png')}
-          style={{ width: '70%' }}
+          source={require('../images/logo.png')}  
+          style={{ width: '70%' , tintColor: '#397af8'}}
           resizeMode="contain"
         />
       </View>


### PR DESCRIPTION
Fixes #128 

### After Fix
**Dark Mode:**
![image](https://user-images.githubusercontent.com/58134096/111039490-5601a600-8454-11eb-99c3-06180df3e12e.png)

**Light Mode:**
![image](https://user-images.githubusercontent.com/58134096/111039524-847f8100-8454-11eb-94ed-7ff30e5cc7aa.png)

### Reasoning: 
There are 3 methods of solving this issue. 

- Create another `logo.png` with the `Hackathon` and the `ReactNative Logo` (top part of the image) in black for light mode and do conditional rendering. This way, you can make the top part of the image black in light mode, and white in dark mode (as it is now)
-  Change the color of the **entire image** based on the toggle state. Implementation (as far as I have tried) looks like this:
`style={[styles.Image, value ? styles.darkmode : styles.lightmode]}`
The problem with this approach is that by doing this, in light mode the entire logo is blue but in dark mode, it remains as it is (top part is white and "STARTER" is in blue) and this looks weird when transitioning
- This is the **ideal and lightweight** method to solve this issue. Make the color for both modes the same (blue). But this time, the logo is clearly visible in both dark and light modes and looks consistent when toggling (as it was before)

Note: The blue gradient used here is the exact same as the one used in "STARTER"

Open to suggestions, and willing to implement them accordingly 🙌🏻 