### PR TITLE
Changed textcolor and alignment in FAB

### DIFF
--- a/src/views/fab.tsx
+++ b/src/views/fab.tsx
@@ -12,16 +12,17 @@ export default () => {
       <View
         style={{
           alignItems: 'center',
+          paddingVertical: 5,
           flexGrow: 1,
         }}
       >
-        <Text>Small Size</Text>
+        <Text style={{color: '#397af8', paddingVertical: 10}}>Small Size</Text>
         <FAB loading visible={visible} iconName="add" size="small" />
-        <Text>Large Size</Text>
+        <Text style={{color: '#397af8', paddingVertical: 10}}>Large Size</Text>
         <FAB visible={visible} iconName="add" color="blue" />
-        <Text>Primary Color</Text>
+        <Text style={{color: '#397af8', paddingVertical: 10}}>Primary Color</Text>
         <FAB visible={visible} label="Navigate" upperCase iconName="place" />
-        <Text>Disabled</Text>
+        <Text style={{color: '#397af8', paddingVertical: 10}}>Disabled</Text>
         <FAB
           visible={visible}
           disabled


### PR DESCRIPTION
Fixes #179 

1. Text color used is the same as the one on the `Hackathon Starter` logo. This ensures that the visibility of the text element is not affected in both Light and Dark modes
2. Padding has been added to make the components uniform across the screen. Also, padding has been given in anticipation of the addition of the new Landscape mode feature. So, FAB is still responsive to the landscape mode as well.