### PR TITLE
Fixed badged avatar in Avatars

### DIFF
--- a/src/views/avatars.tsx
+++ b/src/views/avatars.tsx
@@ -206,7 +206,7 @@ const Avatars: React.FunctionComponent<AvatarComponentProps> = () => {
             rounded
             source={{
               uri:
-                'https://cdn.pixabay.com/photo/2020/06/03/14/53/girl-5255195__340.jpg',
+                'https://randomuser.me/api/portraits/women/57.jpg',
             }}
             title="Bj"
             containerStyle={{ backgroundColor: 'grey' }}


### PR DESCRIPTION
- Minor UI fix that is part of issue #119 
- The PixelBay CDN that was supposed to provide a lady avatar was not working, so I have replaced that URL with a `randomuser` API call. 

**Final Result:**
![image](https://user-images.githubusercontent.com/58134096/112598282-5cb8f180-8e34-11eb-81e4-3272430433b1.png)
