### PR TITLE
Fix all bugs in Login Example screen

### DIFF
--- a/src/views/login/index.tsx
+++ b/src/views/login/index.tsx
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'black',
+    position: 'relative'
   },
 });
 

--- a/src/views/login/screen2.tsx
+++ b/src/views/login/screen2.tsx
@@ -6,7 +6,6 @@ import {
   Dimensions,
   Image,
   UIManager,
-  KeyboardAvoidingView,
   StyleSheet,
   ScrollView,
   Text,
@@ -109,118 +108,113 @@ const LoginScreen3: React.FunctionComponent<LoginScreen3Props> = () => {
       keyboardShouldPersistTaps="handled"
       contentContainerStyle={styles.container}
     >
-      <KeyboardAvoidingView
-        behavior="position"
-        contentContainerStyle={styles.formContainer}
-      >
-        <Text style={styles.signUpText}>Sign up</Text>
-        <Text style={styles.whoAreYouText}>WHO YOU ARE ?</Text>
-        <View style={styles.userTypesContainer}>
-          <UserTypeItem
-            label="COOL"
-            labelColor="#ECC841"
-            image={USER_COOL}
-            onPress={() => selectedTypeHandler('parent')}
-            selected={selectedType === 'parent'}
-          />
-          <UserTypeItem
-            label="STUDENT"
-            labelColor="#2CA75E"
-            image={USER_STUDENT}
-            onPress={() => selectedTypeHandler('child')}
-            selected={selectedType === 'child'}
-          />
-          <UserTypeItem
-            label="HARRY POTTER"
-            labelColor="#36717F"
-            image={USER_HP}
-            onPress={() => selectedTypeHandler('teacher')}
-            selected={selectedType === 'teacher'}
-          />
-        </View>
-        <View style={{ width: '80%', marginLeft: 'auto', marginRight: 'auto' }}>
-          <FormInput
-            refInput={(input) => (usernameInput = input)}
-            icon="user"
-            value={username}
-            onChangeText={(text) => setUsername(text)}
-            placeholder="Username"
-            returnKeyType="next"
-            errorMessage={validUsername ? null : "Your username can't be blank"}
-            onSubmitEditing={() => {
-              validateUsername();
-              emailInput.focus();
-            }}
-          />
-          <FormInput
-            refInput={(input) => (emailInput = input)}
-            icon="envelope"
-            value={email}
-            onChangeText={(text) => setEmail(text)}
-            placeholder="Email"
-            keyboardType="email-address"
-            returnKeyType="next"
-            errorMessage={
-              validEmail ? null : 'Please enter a valid email address'
-            }
-            onSubmitEditing={() => {
-              validateEmail();
-              passwordInput.focus();
-            }}
-          />
-          <FormInput
-            refInput={(input) => (passwordInput = input)}
-            icon="lock"
-            value={password}
-            onChangeText={(text) => setPassword(text)}
-            placeholder="Password"
-            secureTextEntry
-            returnKeyType="next"
-            errorMessage={
-              validPassword ? null : 'Please enter at least 8 characters'
-            }
-            onSubmitEditing={() => {
-              validatePassword();
-              confirmationPasswordInput.focus();
-            }}
-          />
-          <FormInput
-            refInput={(input) => (confirmationPasswordInput = input)}
-            icon="lock"
-            value={confirmationPassword}
-            onChangeText={(text) => setConfirmationPassword(text)}
-            placeholder="Confirm Password"
-            secureTextEntry
-            errorMessage={
-              validConfirmationPassword
-                ? null
-                : 'The password fields are not identical'
-            }
-            returnKeyType="go"
-            onSubmitEditing={() => {
-              validateConfirmationPassword();
-              signup();
-            }}
-          />
-        </View>
-        <Button
-          loading={isLoading}
-          title="SIGNUP"
-          containerStyle={{ flex: -1, marginLeft: 'auto', marginRight: 'auto' }}
-          buttonStyle={styles.signUpButton}
-          linearGradientProps={{
-            colors: ['#FF9800', '#F44336'],
-            start: [1, 0],
-            end: [0.2, 0],
+      <Text style={styles.signUpText}>Sign up</Text>
+      <Text style={styles.whoAreYouText}>WHO YOU ARE ?</Text>
+      <View style={styles.userTypesContainer}>
+        <UserTypeItem
+          label="COOL"
+          labelColor="#ECC841"
+          image={USER_COOL}
+          onPress={() => selectedTypeHandler('parent')}
+          selected={selectedType === 'parent'}
+        />
+        <UserTypeItem
+          label="STUDENT"
+          labelColor="#2CA75E"
+          image={USER_STUDENT}
+          onPress={() => selectedTypeHandler('child')}
+          selected={selectedType === 'child'}
+        />
+        <UserTypeItem
+          label="HARRY POTTER"
+          labelColor="#36717F"
+          image={USER_HP}
+          onPress={() => selectedTypeHandler('teacher')}
+          selected={selectedType === 'teacher'}
+        />
+      </View>
+      <View style={{ width: '80%', marginLeft: 'auto', marginRight: 'auto' }}>
+        <FormInput
+          refInput={(input) => (usernameInput = input)}
+          icon="user"
+          value={username}
+          onChangeText={(text) => setUsername(text)}
+          placeholder="Username"
+          returnKeyType="next"
+          errorMessage={validUsername ? null : "Your username can't be blank"}
+          onSubmitEditing={() => {
+            validateUsername();
+            emailInput.focus();
           }}
-          ViewComponent={LinearGradient}
-          titleStyle={styles.signUpButtonText}
-          onPress={() => {
+        />
+        <FormInput
+          refInput={(input) => (emailInput = input)}
+          icon="envelope"
+          value={email}
+          onChangeText={(text) => setEmail(text)}
+          placeholder="Email"
+          keyboardType="email-address"
+          returnKeyType="next"
+          errorMessage={
+            validEmail ? null : 'Please enter a valid email address'
+          }
+          onSubmitEditing={() => {
+            validateEmail();
+            passwordInput.focus();
+          }}
+        />
+        <FormInput
+          refInput={(input) => (passwordInput = input)}
+          icon="lock"
+          value={password}
+          onChangeText={(text) => setPassword(text)}
+          placeholder="Password"
+          secureTextEntry
+          returnKeyType="next"
+          errorMessage={
+            validPassword ? null : 'Please enter at least 8 characters'
+          }
+          onSubmitEditing={() => {
+            validatePassword();
+            confirmationPasswordInput.focus();
+          }}
+        />
+        <FormInput
+          refInput={(input) => (confirmationPasswordInput = input)}
+          icon="lock"
+          value={confirmationPassword}
+          onChangeText={(text) => setConfirmationPassword(text)}
+          placeholder="Confirm Password"
+          secureTextEntry
+          errorMessage={
+            validConfirmationPassword
+              ? null
+              : 'The password fields are not identical'
+          }
+          returnKeyType="go"
+          onSubmitEditing={() => {
+            validateConfirmationPassword();
             signup();
           }}
-          disabled={isLoading}
         />
-      </KeyboardAvoidingView>
+      </View>
+      <Button
+        loading={isLoading}
+        title="SIGNUP"
+        containerStyle={{ flex: -1, marginLeft: 'auto', marginRight: 'auto' }}
+        buttonStyle={styles.signUpButton}
+        linearGradientProps={{
+          colors: ['#FF9800', '#F44336'],
+          start: [1, 0],
+          end: [0.2, 0],
+        }}
+        ViewComponent={LinearGradient}
+        titleStyle={styles.signUpButtonText}
+        onPress={() => {
+          signup();
+        }}
+        disabled={isLoading}
+      />
       <View style={styles.loginHereContainer}>
         <Text style={styles.alreadyAccountText}>Already have an account.</Text>
         <Button
@@ -295,11 +289,6 @@ const styles = StyleSheet.create({
     height: SCREEN_HEIGHT,
     alignItems: 'center',
     justifyContent: 'space-around',
-  },
-  formContainer: {
-    flex: 1,
-    justifyContent: 'space-around',
-    alignItems: 'center',
   },
   signUpText: {
     color: 'white',

--- a/src/views/login/screen3.tsx
+++ b/src/views/login/screen3.tsx
@@ -8,7 +8,6 @@ import {
   Dimensions,
   LayoutAnimation,
   UIManager,
-  KeyboardAvoidingView,
 } from 'react-native';
 import { Input, Button, Icon } from 'react-native-elements';
 
@@ -129,78 +128,109 @@ export default class LoginScreen2 extends Component<{}, LoginScreen2State> {
       <View style={styles.container}>
         <ImageBackground source={BG_IMAGE} style={styles.bgImage}>
           <View>
-            <KeyboardAvoidingView
-              contentContainerStyle={styles.loginContainer}
-              behavior="position"
-            >
-              <View style={styles.titleContainer}>
-                <View>
-                  <Text style={styles.titleText}>BEAUX</Text>
-                </View>
-                <View style={{ marginLeft: 10 }}>
-                  <Text style={styles.titleText}>VOYAGES</Text>
-                </View>
+            <View style={styles.titleContainer}>
+              <View>
+                <Text style={styles.titleText}>BEAUX</Text>
               </View>
-              <View style={{ flexDirection: 'row' }}>
-                <Button
-                  disabled={isLoading}
-                  type="clear"
-                  activeOpacity={0.7}
-                  onPress={() => this.selectCategory(0)}
-                  containerStyle={{ flex: 1 }}
-                  titleStyle={[
-                    styles.categoryText,
-                    isLoginPage && styles.selectedCategoryText,
-                  ]}
-                  title={'Login'}
-                />
-                <Button
-                  disabled={isLoading}
-                  type="clear"
-                  activeOpacity={0.7}
-                  onPress={() => this.selectCategory(1)}
-                  containerStyle={{ flex: 1 }}
-                  titleStyle={[
-                    styles.categoryText,
-                    isSignUpPage && styles.selectedCategoryText,
-                  ]}
-                  title={'Sign up'}
-                />
+              <View style={{ marginLeft: 10 }}>
+                <Text style={styles.titleText}>VOYAGES</Text>
               </View>
-              <View style={styles.rowSelector}>
-                <TabSelector selected={isLoginPage} />
-                <TabSelector selected={isSignUpPage} />
-              </View>
-              <View style={styles.formContainer}>
-                <Input
-                  leftIcon={
-                    <Icon
-                      name="envelope-o"
-                      type="font-awesome"
-                      color="rgba(0, 0, 0, 0.38)"
-                      size={25}
-                      style={{ backgroundColor: 'transparent' }}
-                    />
-                  }
-                  value={email}
-                  keyboardAppearance="light"
-                  autoFocus={false}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="email-address"
-                  returnKeyType="next"
-                  inputStyle={{ marginLeft: 10, color: 'grey'}}
-                  placeholder={'Email'}
-                  containerStyle={{
-                    borderBottomColor: 'rgba(0, 0, 0, 0.38)',
-                  }}
-                  ref={(input) => (this.emailInput = input)}
-                  onSubmitEditing={() => this.passwordInput.focus()}
-                  onChangeText={(text) => this.setState({ email: text })}
-                  errorMessage={
-                    isEmailValid ? null : 'Please enter a valid email address'
-                  }
-                />
+            </View>
+            <View style={{ flexDirection: 'row' }}>
+              <Button
+                disabled={isLoading}
+                type="clear"
+                activeOpacity={0.7}
+                onPress={() => this.selectCategory(0)}
+                containerStyle={{ flex: 1 }}
+                titleStyle={[
+                  styles.categoryText,
+                  isLoginPage && styles.selectedCategoryText,
+                ]}
+                title={'Login'}
+              />
+              <Button
+                disabled={isLoading}
+                type="clear"
+                activeOpacity={0.7}
+                onPress={() => this.selectCategory(1)}
+                containerStyle={{ flex: 1 }}
+                titleStyle={[
+                  styles.categoryText,
+                  isSignUpPage && styles.selectedCategoryText,
+                ]}
+                title={'Sign up'}
+              />
+            </View>
+            <View style={styles.rowSelector}>
+              <TabSelector selected={isLoginPage} />
+              <TabSelector selected={isSignUpPage} />
+            </View>
+            <View style={styles.formContainer}>
+              <Input
+                leftIcon={
+                  <Icon
+                    name="envelope-o"
+                    type="font-awesome"
+                    color="rgba(0, 0, 0, 0.38)"
+                    size={25}
+                    style={{ backgroundColor: 'transparent' }}
+                  />
+                }
+                value={email}
+                keyboardAppearance="light"
+                autoFocus={false}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="email-address"
+                returnKeyType="next"
+                inputStyle={{ marginLeft: 10, color: 'grey'}}
+                placeholder={'Email'}
+                containerStyle={{
+                  borderBottomColor: 'rgba(0, 0, 0, 0.38)',
+                }}
+                ref={(input) => (this.emailInput = input)}
+                onSubmitEditing={() => this.passwordInput.focus()}
+                onChangeText={(text) => this.setState({ email: text })}
+                errorMessage={
+                  isEmailValid ? null : 'Please enter a valid email address'
+                }
+              />
+              <Input
+                leftIcon={
+                  <Icon
+                    name="lock"
+                    type="simple-line-icon"
+                    color="rgba(0, 0, 0, 0.38)"
+                    size={25}
+                    style={{ backgroundColor: 'transparent' }}
+                  />
+                }
+                value={password}
+                keyboardAppearance="light"
+                autoCapitalize="none"
+                autoCorrect={false}
+                secureTextEntry={true}
+                returnKeyType={isSignUpPage ? 'next' : 'done'}
+                blurOnSubmit={true}
+                containerStyle={{
+                  marginTop: 16,
+                  borderBottomColor: 'rgba(0, 0, 0, 0.38)',
+                }}
+                inputStyle={{ marginLeft: 10, color: 'grey' }}
+                placeholder={'Password'}
+                ref={(input) => (this.passwordInput = input)}
+                onSubmitEditing={() =>
+                  isSignUpPage ? this.confirmationInput.focus() : this.login()
+                }
+                onChangeText={(text) => this.setState({ password: text })}
+                errorMessage={
+                  isPasswordValid
+                  ? null
+                  : 'Please enter at least 8 characters'
+                }
+              />
+              {isSignUpPage && (
                 <Input
                   leftIcon={
                     <Icon
@@ -211,79 +241,43 @@ export default class LoginScreen2 extends Component<{}, LoginScreen2State> {
                       style={{ backgroundColor: 'transparent' }}
                     />
                   }
-                  value={password}
+                  value={passwordConfirmation}
+                  secureTextEntry={true}
                   keyboardAppearance="light"
                   autoCapitalize="none"
                   autoCorrect={false}
-                  secureTextEntry={true}
-                  returnKeyType={isSignUpPage ? 'next' : 'done'}
+                  keyboardType="default"
+                  returnKeyType={'done'}
                   blurOnSubmit={true}
                   containerStyle={{
                     marginTop: 16,
                     borderBottomColor: 'rgba(0, 0, 0, 0.38)',
                   }}
                   inputStyle={{ marginLeft: 10, color: 'grey' }}
-                  placeholder={'Password'}
-                  ref={(input) => (this.passwordInput = input)}
-                  onSubmitEditing={() =>
-                    isSignUpPage ? this.confirmationInput.focus() : this.login()
+                  placeholder={'Confirm password'}
+                  ref={(input) => (this.confirmationInput = input)}
+                  onSubmitEditing={this.signUp}
+                  onChangeText={(text) =>
+                    this.setState({ passwordConfirmation: text })
                   }
-                  onChangeText={(text) => this.setState({ password: text })}
                   errorMessage={
-                    isPasswordValid
+                    isConfirmationValid
                       ? null
-                      : 'Please enter at least 8 characters'
+                      : 'Please enter the same password'
                   }
                 />
-                {isSignUpPage && (
-                  <Input
-                    leftIcon={
-                      <Icon
-                        name="lock"
-                        type="simple-line-icon"
-                        color="rgba(0, 0, 0, 0.38)"
-                        size={25}
-                        style={{ backgroundColor: 'transparent' }}
-                      />
-                    }
-                    value={passwordConfirmation}
-                    secureTextEntry={true}
-                    keyboardAppearance="light"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    keyboardType="default"
-                    returnKeyType={'done'}
-                    blurOnSubmit={true}
-                    containerStyle={{
-                      marginTop: 16,
-                      borderBottomColor: 'rgba(0, 0, 0, 0.38)',
-                    }}
-                    inputStyle={{ marginLeft: 10, color: 'grey' }}
-                    placeholder={'Confirm password'}
-                    ref={(input) => (this.confirmationInput = input)}
-                    onSubmitEditing={this.signUp}
-                    onChangeText={(text) =>
-                      this.setState({ passwordConfirmation: text })
-                    }
-                    errorMessage={
-                      isConfirmationValid
-                        ? null
-                        : 'Please enter the same password'
-                    }
-                  />
-                )}
-                <Button
-                  buttonStyle={styles.loginButton}
-                  containerStyle={{ marginTop: 32, flex: 0 }}
-                  activeOpacity={0.8}
-                  title={isLoginPage ? 'LOGIN' : 'SIGN UP'}
-                  onPress={isLoginPage ? this.login : this.signUp}
-                  titleStyle={styles.loginTextButton}
-                  loading={isLoading}
-                  disabled={isLoading}
-                />
-              </View>
-            </KeyboardAvoidingView>
+              )}
+              <Button
+                buttonStyle={styles.loginButton}
+                containerStyle={{ marginTop: 32, flex: 0 }}
+                activeOpacity={0.8}
+                title={isLoginPage ? 'LOGIN' : 'SIGN UP'}
+                onPress={isLoginPage ? this.login : this.signUp}
+                titleStyle={styles.loginTextButton}
+                loading={isLoading}
+                disabled={isLoading}
+              />
+            </View>
             <View style={styles.helpContainer}>
               <Button
                 title={'Need help ?'}
@@ -327,10 +321,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 70,
     borderColor: 'white',
     backgroundColor: 'white',
-  },
-  loginContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   loginTextButton: {
     fontSize: 16,

--- a/src/views/login/screen3.tsx
+++ b/src/views/login/screen3.tsx
@@ -288,7 +288,7 @@ export default class LoginScreen2 extends Component<{}, LoginScreen2State> {
                 title={'Need help ?'}
                 titleStyle={{ color: 'white' }}
                 buttonStyle={{ backgroundColor: 'transparent' }}
-                onPress={() => console.log('Account created')}
+                onPress={() => Alert.alert('🤔', 'Forgot Password Route')}
               />
             </View>
           </View>

--- a/src/views/login/screen3.tsx
+++ b/src/views/login/screen3.tsx
@@ -89,7 +89,9 @@ export default class LoginScreen2 extends Component<{}, LoginScreen2State> {
         isEmailValid: this.validateEmail(email) || this.emailInput.shake(),
         isPasswordValid: password.length >= 8 || this.passwordInput.shake(),
       });
-      Alert.alert('🔥', 'Successfully Logged In');
+      if(this.state.isEmailValid && 
+        this.state.isPasswordValid) 
+        Alert.alert('🔥', 'Successfully Logged In');
     }, 1500);
   }
 
@@ -106,7 +108,10 @@ export default class LoginScreen2 extends Component<{}, LoginScreen2State> {
         isConfirmationValid:
           password === passwordConfirmation || this.confirmationInput.shake(),
       });
-      Alert.alert('🙏', 'Welcome');
+      if(this.state.isEmailValid && 
+        this.state.isPasswordValid && 
+        this.state.isConfirmationValid) 
+        Alert.alert('🙏', 'Welcome');
     }, 1500);
   }
 


### PR DESCRIPTION
**The problem:**
**TLDR**: Both screens in Login Example are now part of the same screen. KeyboardAvoidingView treats them as 2 separate components and causes bugs in Portrait and especially Landscape mode. This PR solves that issue. 

When form input is clicked in both Screen2 and 3, the entire view goes up and gets permanently hidden. The reason behind this bug is the KeyboardAvoidingView (KAV) which pushes the elements up upon clicking a form input.

Now, this library was required when both the Screen2 and 3 were in different sections (which can be accessed by sliding right), but now both the Screens are on the same page to avoid confusion and enable Landscape mode. This makes the KAV library redundant, as the forms in both Screens can just be scrolled both in Portrait and Landscape modes. 

**To replicate the bug:**
In both Portrait and Landscape modes, try to fill values in Screen2 and 3 on `LoginExample` page. Not using KAV gives a much better UI experience. 

Open to suggestions, and willing to implement them 🙌🏻 