### PR TITLE
Fixed multiple UI bugs 

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
       "web"
     ],
     "version": "1.1.0",
-    "orientation": "any",
+    "orientation": "default",
     "primaryColor": "#cccccc",
     "icon": "./assets/icons/icon.png",
     "splash": {

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -41,6 +41,7 @@ function CustomContentComponent(props) {
           flexDirection: 'row',
           width: '100%',
           paddingLeft: 25,
+          paddingBottom: 5,
         }}
       >
         <Text

--- a/src/views/checkbox.tsx
+++ b/src/views/checkbox.tsx
@@ -57,7 +57,7 @@ const CheckboxComponent: React.FunctionComponent<CheckboxComponentProps> = () =>
           <Icon
             name="radio-button-unchecked"
             type="material"
-            color="black"
+            color="grey"
             size={25}
             iconStyle={{ marginRight: 10 }}
           />

--- a/src/views/header.tsx
+++ b/src/views/header.tsx
@@ -45,10 +45,10 @@ const styles = StyleSheet.create({
   headerContainer: {
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#ED553B',
+    backgroundColor: '#397af8',
     marginBottom: 20,
     width:"100%",
-    paddingVertical:10
+    paddingVertical:15,
   },
   heading: {
     color: 'white',

--- a/src/views/inputs.tsx
+++ b/src/views/inputs.tsx
@@ -16,7 +16,7 @@ import {
   ThemeProvider,
   InputProps,
 } from 'react-native-elements';
-import { Header } from './header';
+import { Header, SubHeader } from './header';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const dummySearchBarProps = {
@@ -42,7 +42,7 @@ const Inputs: React.FunctionComponent<InputsComponentProps> = () => {
   let confirmPassword2Input = useRef(null);
 
   const InputFieldsStyle = {
-    borderWidth: 0,
+    borderWidth: 0   
   };
 
   const inputProps = {};
@@ -55,9 +55,8 @@ const Inputs: React.FunctionComponent<InputsComponentProps> = () => {
     >
       <Header title="Inputs" />
       <ScrollView keyboardShouldPersistTaps="handled">
-        <View style={styles.headerContainer}>
-          <Icon color="white" name="search" size={62} />
-          <Text style={styles.heading}>Search Bars</Text>
+        <View>
+          <SubHeader title={'Search Bars'} />
         </View>
         <SearchBarCustom
           placeholder="iOS searchbar"
@@ -76,14 +75,8 @@ const Inputs: React.FunctionComponent<InputsComponentProps> = () => {
           style={InputFieldsStyle}
           {...dummySearchBarProps}
         />
-        <View
-          style={[
-            styles.headerContainer,
-            { backgroundColor: '#616389', marginTop: 20 },
-          ]}
-        >
-          <Icon color="white" name="input" size={62} />
-          <Text style={styles.heading}>Inputs</Text>
+        <View style={{paddingTop: 30}}>
+          <SubHeader title={'Inputs'} />
         </View>
         <View style={{ alignItems: 'center', marginBottom: 16 }}>
           <Input
@@ -388,12 +381,6 @@ const Inputs: React.FunctionComponent<InputsComponentProps> = () => {
 export default Inputs;
 
 const styles = StyleSheet.create({
-  headerContainer: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 40,
-    backgroundColor: '#B46486',
-  },
   heading: {
     color: 'white',
     marginTop: 10,

--- a/src/views/lists/content.tsx
+++ b/src/views/lists/content.tsx
@@ -5,7 +5,7 @@ import { Avatar, Button, Icon, withTheme } from 'react-native-elements';
 
 const USERS = [
   {
-    name: 'Johh Smith',
+    name: 'John Smith',
     avatar: 'https://uifaces.co/our-content/donated/1H_7AxP0.jpg',
     value: '- 164',
   },
@@ -17,7 +17,7 @@ const USERS = [
     positive: true,
   },
   {
-    name: 'Paul Allen',
+    name: 'Barry Allen',
     avatar: 'https://uifaces.co/our-content/donated/bUkmHPKs.jpg',
     value: '+ 464',
     positive: true,

--- a/src/views/overlay.tsx
+++ b/src/views/overlay.tsx
@@ -24,7 +24,7 @@ const OverlayComponent: React.FunctionComponent<OverlayComponentProps> = () => {
       <Overlay isVisible={visible} onBackdropPress={toggleOverlay}>
         <Text style={styles.textPrimary}>Hello!</Text>
         <Text style={styles.textSecondary}>
-          Welcome to react native training
+          Welcome to React Native Elements
         </Text>
         <Button
           icon={
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
   },
   textSecondary: {
-    marginVertical: 20,
+    marginBottom: 10,
     textAlign: 'center',
     fontSize: 17,
   },

--- a/src/views/settings.tsx
+++ b/src/views/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { View, StyleSheet, SectionList } from 'react-native';
 import {
   ListItem,
@@ -9,6 +9,8 @@ import {
   Switch,
 } from 'react-native-elements';
 import { Header } from './header';
+import { ThemeReducerContext } from '../helpers/ThemeReducer';
+
 
 const ORANGE = '#FF9500';
 const BLUE = '#007AFF';
@@ -122,6 +124,7 @@ type SetttingsComponentProps = {};
 
 const Settings: React.FunctionComponent<SetttingsComponentProps> = () => {
   const [switched, setSwitched] = useState(false);
+  const { ThemeState } = useContext(ThemeReducerContext);
 
   const onSwitchEventHandler = (value) => {
     setSwitched(value);
@@ -163,7 +166,7 @@ const Settings: React.FunctionComponent<SetttingsComponentProps> = () => {
   const renderSectionHeader = () => <View style={styles.headerSection} />;
 
   const ItemSeparatorComponent = () => (
-    <View style={styles.separatorComponent}>
+    <View style={[ThemeState.themeMode === 'dark'? styles.separatorComponentDark: styles.separatorComponentLight]}>
       <Divider style={styles.separator} />
     </View>
   );
@@ -202,8 +205,11 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: '#EFEFF4',
   },
-  separatorComponent: {
+  separatorComponentLight: {
     backgroundColor: 'white',
+  },
+  separatorComponentDark: {
+    backgroundColor: 'black',
   },
   separator: {
     marginLeft: 58,

--- a/src/views/text.tsx
+++ b/src/views/text.tsx
@@ -30,7 +30,7 @@ const TextComponent: React.FunctionComponent<TextComponentProps> = () => {
           Heading 4
         </Text>
         <View style={styles.more}>
-          <Text style={[styles.text, { color: 'grey' }]}>
+          <Text style={[styles.text, { color: 'grey', padding: 20 }]}>
             Refer docs for more:
           </Text>
           <Button
@@ -50,6 +50,7 @@ const styles = StyleSheet.create({
   },
   text: {
     textAlign: 'center',
+    padding: 5,
   },
   more: {
     marginVertical: 20,

--- a/src/views/tiles.tsx
+++ b/src/views/tiles.tsx
@@ -64,7 +64,7 @@ const Tiles: React.FunctionComponent<TilesComponentProps> = () => {
                 }}
               >
                 <Text style={{ color: 'green' }}>Visit</Text>
-                <Text style={{ color: 'blue' }}>Find out More</Text>
+                <Text style={{ color: '#397af8' }}>Find out More</Text>
               </View>
             </Tile>
           </View>


### PR DESCRIPTION
### A breakdown of everything this PR achieves:

- Padding has been added between the `Dark Mode Switch` component and the Divider in the side-drawer
- Previously, the last checkbox on the `Checkbox` page became invisible in Dark Mode, as the color of the `unCheckedIcon` was black. It has been converted to grey to be visible in both Dark and Light Modes. 
- **Major Change:** The obnoxiously bright orange color of the SubHeader has been converted into the same color as the logo in the side-drawer. The reason I did this is to ensure that the entirety of the app has only a small palette of colors (for uniformity. Orange was not used anywhere else in the app except the Subheader, and hence looked odd) and I have already changed the color of many other elements in other PRs to this color. The size of the SubHeader has also been slightly increased. The new-look has been checked in both Light and Dark modes to ensure that visibility is not affected at all.
- The off-the-place looking subheaders in the `Inputs` page have been replaced with the standard SubHeader. This is to ensure uniformity. 
- A few name typos on the `Lists` page have been fixed.
- Minor modifications on the `Overlay` page to look similar to the image in the documentation. 
- **Improvement:** Previously, the `ItemSeparatorComponent` in the `Settings Example` had only one color, and hence in Dark Mode, the white color (used to make LightMode look similar to iOS settings) caused problems by looking out of place. To fix it, I have added conditional rendering which changes this component's color to black in Dark mode and white in Light Mode. Now, the page replicates the iOS look perfectly in both modes.
- Sufficient padding has been given on the `Text` page to de-clutter the components from the top.
- Color of the `Find out More` component in `Tiles` is changed from dark blue as it looked a bit weird in Dark Mode. 

Open to suggestions, and willing to implement them immediately 🙌🏻