### PR TITLE
UI Fixes 

### DIFF
--- a/src/views/fab.tsx
+++ b/src/views/fab.tsx
@@ -31,7 +31,7 @@ export default () => {
         <FAB
           visible={visible}
           icon={{ name: 'add', color: 'white' }}
-          color="blue"
+          color="green"
         />
         <Text style={{ color: '#397af8', paddingVertical: 10 }}>
           Primary Color
@@ -60,7 +60,7 @@ export default () => {
           placement="right"
           title="Hide"
           icon={{ name: 'delete', color: 'white' }}
-          color="blue"
+          color="red"
         />
         <FAB
           visible={!visible}

--- a/src/views/inputs.tsx
+++ b/src/views/inputs.tsx
@@ -7,6 +7,7 @@ import {
   Dimensions,
   KeyboardAvoidingView,
   Platform,
+  Vibration,
 } from 'react-native';
 import {
   Input,
@@ -138,7 +139,7 @@ const Inputs: React.FunctionComponent<InputsComponentProps> = () => {
             rightIcon={
               <Button
                 title="Shake"
-                onPress={() => shakeInput && shakeInput.shake()}
+                onPress={() => {shakeInput && shakeInput.shake(); Vibration.vibrate(1000)}} 
               />
             }
             errorMessage="Shake me on error !"

--- a/src/views/lists2.tsx
+++ b/src/views/lists2.tsx
@@ -174,7 +174,7 @@ const Lists2: React.FunctionComponent<ListComponentProps> = () => {
             <View style={styles.list}>
               {list2.map((l, i) => (
                 <ListItem key={i} bottomDivider>
-                  <Icon name="user-circle-o" type="font-awesome" color="blue" />
+                  <Icon name="user-circle-o" type="font-awesome" color="red" />
                   <ListItem.Content>
                     <ListItem.Title style={{ color: 'red' }}>
                       {l.name}

--- a/src/views/sliders.tsx
+++ b/src/views/sliders.tsx
@@ -34,7 +34,7 @@ const Sliders: React.FunctionComponent<SlidersComponentProps> = () => {
           minimumValue={0}
           step={1}
           allowTouchTrack
-          trackStyle={{ height: 10, backgroundColor: 'transparent' }}
+          trackStyle={{ height: 5, backgroundColor: 'transparent' }}
           thumbStyle={{ height: 20, width: 20, backgroundColor: 'transparent' }}
           thumbProps={{
             children: (

--- a/src/views/social_icons.tsx
+++ b/src/views/social_icons.tsx
@@ -113,7 +113,7 @@ const SocialIcons: React.FunctionComponent<SocialIconsComponentProps> = () => {
                 flexDirection: 'row',
                 justifyContent: 'space-around',
                 marginTop: 10,
-                backgroundColor: 'grey',
+                backgroundColor: '#4c4c4c',
               }}
               key={chunkIndex}
             >

--- a/src/views/tiles.tsx
+++ b/src/views/tiles.tsx
@@ -50,7 +50,7 @@ const Tiles: React.FunctionComponent<TilesComponentProps> = () => {
                   'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Half_Dome_from_Glacier_Point%2C_Yosemite_NP_-_Diliff.jpg/320px-Half_Dome_from_Glacier_Point%2C_Yosemite_NP_-_Diliff.jpg',
               }}
               title="Half Dome, Yosemite"
-              titleStyle={{ fontSize: 20 }}
+              titleStyle={{ fontSize: 20, textAlign: 'center', paddingBottom: 5 }}
               activeOpacity={1}
               width={310}
               contentContainerStyle={{ height: 70 }}

--- a/src/views/tiles.tsx
+++ b/src/views/tiles.tsx
@@ -14,10 +14,10 @@ const Tiles: React.FunctionComponent<TilesComponentProps> = () => {
           <Tile
             imageSrc={{
               uri:
-                'https://images.squarespace-cdn.com/content/v1/5477887ae4b07c97883111ab/1474363728860-6JTDG9X57ZWV4GPF22SB/ke17ZwdGBToddI8pDm48kCODrNtbcuYH7-tCzItriTR7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0geeCvn1f36QDdcifB7yxGil1S52LO7OFJ9VSg5prgfv6LcGlOWReXeb5jU_5wp_mQ/Porthmeor+Sunset+21.jpg?format=300w',
+                'https://www.mediastorehouse.com/p/191/sunset-porthmeor-beach-st-ives-cornwall-11702500.jpg.webp',
             }}
             title="When I admire the wonders of a sunset or the beauty of the moon, my soul expands in the worship of the creator."
-            titleStyle={{ fontSize: 20 }}
+            titleStyle={{ fontSize: 15 }}
             featured
             caption="Mahatma Gandhi"
             activeOpacity={1}

--- a/src/views/whatsappClone.tsx
+++ b/src/views/whatsappClone.tsx
@@ -15,6 +15,7 @@ import {
   Badge,
   Tab,
 } from 'react-native-elements';
+import { Header } from '../components/header';
 
 const ScreenWidth = Dimensions.get('window').width;
 
@@ -24,9 +25,10 @@ const WhatsappClone: React.FunctionComponent = () => {
 
   return (
     <>
+    <Header title="Whatsapp Clone" />
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.header1}>
-          <Text style={{ color: '#fff', fontSize: 20, flexGrow: 1 }}>
+          <Text style={{ color: '#fff', fontSize: 20, flexGrow: 1, fontWeight: 'bold'}}>
             WhatsApp
           </Text>
           <Icon name="search" color="white" style={styles.icon} />
@@ -59,7 +61,7 @@ const WhatsappClone: React.FunctionComponent = () => {
             style={{ backgroundColor: 'transparent' }}
           >
             <Tab.Item
-              title="chat"
+              title="chats"
               titleStyle={{ color: '#fff' }}
               containerStyle={{ backgroundColor: 'transparent' }}
             />


### PR DESCRIPTION
### Major Changes in this PR
- Made FAB icons less contrasting in dark mode 
- Added vibration feature to `Shake input` to make it feel more natural
- Fixed broken CDN in Tiles. Replaced it with the same image theme as before
- Added header to Whatsapp Clone. The sliding between `Chats, Status, and Calls` made it very difficult to access the Drawer, and it wasn't a good UI experience. Also, to maintain uniformity throughout the app. 
- Made background of Social Icons less contrasting with the background while maintaining visibility of all icons
